### PR TITLE
Handlers: Update logic to render test plans

### DIFF
--- a/Handlers/argParseHandler.py
+++ b/Handlers/argParseHandler.py
@@ -27,7 +27,7 @@ class ArgParseHandler:
             logging.debug('Parsed test names from test_data')
 
             for test_name in test_names:
-                arg_name = test_name["name"]
+                arg_name = test_name["name"].removesuffix(".yaml")
                 parser.add_argument('--' + arg_name, help=f'Example: {test_name["name"]} argument', action="store_true")
                 logging.debug(f'Added argument for test name: {arg_name}')
 

--- a/Handlers/dataHandler.py
+++ b/Handlers/dataHandler.py
@@ -167,20 +167,23 @@ class DataHandler:
     
     def put_tests_into_fetched_data(self, test_names, arg_parse_handler, test_data):
         logging.debug('put_tests_into_fetched_data called with test_names: %s', test_names)
+        logging.debug('put_tests_into_fetched_data called with test_data: %s', test_data)
         for test_name in test_names:
             # arg_name_original = test_name["name"]
-            arg_name = test_name["name"].replace('-', '_')
+            arg_name = test_name["name"].removesuffix(".yaml").replace('-', '_')
+            print("arg_name", arg_name)
             if arg_parse_handler.is_argname_passed(arg_name=arg_name):
-                logging.info(f"You have used '--{test_name['name']}' argument")
+                logging.info(f"You have used '--{arg_name}' argument")
                 print(f"You have used '--{test_name['name']}' argument")
                 # pushing tests into the data's tests list
-                specific_test_paths = filter_data(test_data,folder_name='/'+test_name['name']+'/', data_type='yaml')
+                specific_test_paths = filter_data(test_data,folder_name='/'+test_name['name'], data_type='yaml')
+                print("specific_test_paths",specific_test_paths)
                 for specific_test_path in specific_test_paths:
                     specific_test_name = self.extract_test_name(specific_test_path)
                     self.data.setdefault("tests", []).append({
-                        "repository": "https://github.com/qualcomm-linux/test-definitions.git",
+                        "repository": "https://github.com/qualcomm-linux/qcom-linux-testkit.git",
                         "from": "git",
-                        "path": f"{specific_test_path}",
+                        "path": f"Runner/plans{specific_test_path}",
                         "name": f"{specific_test_name}-tests"
                     })
                     self.tests_count+=1

--- a/templates/lava_job_template.jinja2
+++ b/templates/lava_job_template.jinja2
@@ -10,7 +10,7 @@ actions:
     {% for test in node.tests %}
     - repository: "{{test.repository}}"
       from: "{{test.from}}"
-      path: automated/linux{{test.path}}
+      path: {{test.path}}
       name: "{{test.name}}"
     {% endfor %}
 {% endif %}

--- a/testList.json
+++ b/testList.json
@@ -1,0 +1,8 @@
+[
+  {"type":"directory","name":".","contents":[
+    {"type":"file","name":"KernelCI_PreMerge.yaml"},
+    {"type":"file","name":"meta-qcom_PreMerge.yaml"}
+  ]}
+,
+  {"type":"report","directories":0,"files":2}
+]


### PR DESCRIPTION
Update logic to render the test plan definition.
Adding  a test plan parameter to lava job generator, this will 
fetch required test definitions to generate the test plan as part of
lava_job_definition.yml file.