### PR TITLE
Rename: KernelCI_PreMerge.yaml to qcom-next-ci-premerge.yaml

### DIFF
--- a/testList.json
+++ b/testList.json
@@ -1,6 +1,6 @@
 [
   {"type":"directory","name":".","contents":[
-    {"type":"file","name":"KernelCI_PreMerge.yaml"},
+    {"type":"file","name":"qcom-next-ci-premerge.yaml"},
     {"type":"file","name":"meta-qcom_PreMerge.yaml"}
   ]}
 ,


### PR DESCRIPTION
Updated the filename from KernelCI_PreMerge.yaml to qcom-next-ci-premerge.yaml to better reflect the content and purpose of the file.