### PR TITLE
templates: fix initramfs merge to preserve filesystem structure and symlinks (avoid cat)

### DIFF
--- a/templates/boot/fastboot.jinja2
+++ b/templates/boot/fastboot.jinja2
@@ -29,14 +29,18 @@
       docker:
         image: ghcr.io/mwasilew/docker-mkbootimage:master
         steps:
-        - gunzip -c {{ ramdisk_name }} > initramfs-kerneltest-full-image-qcom-armv8a.cpio
         {% if firmware_name %}
-        - gunzip -c {{ firmware_name }} > initramfs-firmware-rb3gen2-image-qcom-armv8a.cpio
-        - cat initramfs-kerneltest-full-image-qcom-armv8a.cpio initramfs-firmware-rb3gen2-image-qcom-armv8a.cpio > merged-initramfs.cpio
+        - rm -rf rootfs
+        - mkdir -p rootfs
+        - cd rootfs
+        - gzip -cd ../{{ ramdisk_name }} | cpio -idm --no-absolute-filenames
+        - gzip -cd ../{{ firmware_name }} | cpio -idm --no-absolute-filenames
+        - find . -print0 | cpio --null -H newc -o | gzip -9 > ../merged-initramfs.cpio.gz
+        - cd ..
         {% else %}
-        - cat initramfs-kerneltest-full-image-qcom-armv8a.cpio > merged-initramfs.cpio
+        # No firmware to merge: rename ramdisk as merged output (destructive)
+        - mv {{ ramdisk_name }} merged-initramfs.cpio.gz
         {% endif %}
-        - gzip merged-initramfs.cpio
         - mkbootimg --header_version 2 --kernel Image --dtb {{ dtb_name }} --cmdline "console=ttyMSM0,115200n8 earlycon qcom_geni_serial.con_enabled=1 kernel.sched_pelt_multiplier=4 mem_sleep_default=s2idle mitigations=auto video=efifb:off" --ramdisk merged-initramfs.cpio.gz --output boot.img
     to: downloads
 


### PR DESCRIPTION
### Summary

This PR updates the initramfs merging logic in the fastboot template to **avoid using `cat`** for combining initramfs/firmware archives. Instead, when a firmware archive is present, we **extract both archives into a single staging directory and repack** them into a unified `merged-initramfs.cpio.gz`.

### Problem

The previous approach concatenated cpio files using `cat`:

```sh
cat initramfs-kerneltest-full-image-qcom-armv8a.cpio \
    initramfs-firmware-rb3gen2-image-qcom-armv8a.cpio \
  > merged-initramfs.cpio
gzip merged-initramfs.cpio
```

This is a byte-stream concatenation and **does not actually merge filesystem trees**. When one archive provides symlinks (e.g., `/lib -> /usr/lib`) and the other provides firmware files, early boot path resolution can break (e.g., `/lib/firmware` not resolving correctly), causing firmware load failures.

### Solution

When `firmware_name` is provided, we now perform a correct merge:

1.  Create a staging directory (`rootfs`)
2.  Extract the base ramdisk into it
3.  Extract the firmware archive into the same directory (overlay merge)
4.  Repack into a single `newc` initramfs archive (`merged-initramfs.cpio.gz`)

This preserves:

*   directory hierarchy
*   symlinks
*   correct final file placement for early boot firmware loading

### Scope / Impact

*   Only affects this initramfs merge step.
*   Improves correctness when firmware is supplied as a separate archive.
*   Maintains the output artifact naming expected by downstream steps (`merged-initramfs.cpio.gz`).

