### PR TITLE
Support remoteproc boot arguments in job definitions

### DIFF
--- a/lava_Job_definition_generator.py
+++ b/lava_Job_definition_generator.py
@@ -19,6 +19,7 @@ name = os.environ.get("TARGET")
 target_dtb = os.environ.get("TARGET_DTB")
 flash_image = os.environ.get("FLASH_IMAGE")
 flash_port = os.environ.get("FLASH_PORT", "0")
+default_boot_args = os.environ.get("DEFAULT_BOOT_ARGS", "")
 brarch = 'arm64'
 
 
@@ -137,7 +138,6 @@ if test_data is not None:
 
 ### Render the template with dynamic data
 node_data = data_handler.get_fetched_data()
-job_definition = template_handler.render_template(template, node=data_handler.get_fetched_data(), platform_config=platform_config, test_method=test_method, tests_count=data_handler.get_count_of_tests(), device_dtb=node_data['artifacts']['dtb'], brarch=brarch, flash_port=flash_port, meta_qcom=meta_qcom_enabled)
-
+job_definition = template_handler.render_template(template, node=data_handler.get_fetched_data(), platform_config=platform_config, test_method=test_method, tests_count=data_handler.get_count_of_tests(), device_dtb=node_data['artifacts']['dtb'], brarch=brarch, flash_port=flash_port, meta_qcom=meta_qcom_enabled, default_boot_args=default_boot_args)
 # Parse the rendered YAML and Save the rendered job definition
 template_handler.save_rendered_template(job_definition, os.path.join('renders','lava_job_definition.yaml'))

--- a/templates/boot/fastboot.jinja2
+++ b/templates/boot/fastboot.jinja2
@@ -37,7 +37,7 @@
         - cat initramfs-kerneltest-full-image-qcom-armv8a.cpio > merged-initramfs.cpio
         {% endif %}
         - gzip merged-initramfs.cpio
-        - mkbootimg --header_version 2 --kernel Image --dtb {{ dtb_name }} --cmdline "console=ttyMSM0,115200n8 earlycon qcom_geni_serial.con_enabled=1 kernel.sched_pelt_multiplier=4 mem_sleep_default=s2idle mitigations=auto video=efifb:off" --ramdisk merged-initramfs.cpio.gz --output boot.img
+        - mkbootimg --header_version 2 --kernel Image --dtb {{ dtb_name }} --cmdline "console=ttyMSM0,115200n8 earlycon qcom_geni_serial.con_enabled=1 kernel.sched_pelt_multiplier=4 mem_sleep_default=s2idle mitigations=auto video=efifb:off {{ default_boot_args }}" --ramdisk merged-initramfs.cpio.gz --output boot.img
     to: downloads
 
 - deploy:


### PR DESCRIPTION
### Summary
Add support for dynamic kernel boot arguments in LAVA job definitions by introducing the `default_boot_args` parameter.

### Changes
- **lava_Job_definition_generator.py**: Read `DEFAULT_BOOT_ARGS` from environment and pass to template renderer
- **templates/boot/fastboot.jinja2**: Append boot arguments to kernel cmdline using Jinja2 conditional

**Example output:**
```bash
--cmdline "console=ttyMSM0,115200n8 ... video=efifb:off pd_ignore_unused clk_ignore_unused"
```
### Dependencies
Requires corresponding changes in the `fastrpc` repository to pass `DEFAULT_BOOT_ARGS` environment variable.

---

**Related PR**: 
https://github.com/qualcomm-linux-stg/fastrpc/pull/114