### PR TITLE
boot: Update docker image for fastboot and efi templates

### DIFF
--- a/templates/boot/efi.jinja2
+++ b/templates/boot/efi.jinja2
@@ -38,7 +38,7 @@
 {% endif %}
     postprocess:
       docker:
-        image: <TODO>
+        image: artifacts.codelinaro.org/clo-420-qli-registry/kmake-image-ci:ver.1.0
         steps:
 {%- if node.data.kernel_type.endswith('.gz') %}
         - gunzip Image.gz

--- a/templates/boot/fastboot.jinja2
+++ b/templates/boot/fastboot.jinja2
@@ -27,7 +27,7 @@
 {% set ramdisk_name = ramdisk_path.split('/')[-1] %}
     postprocess:
       docker:
-        image: ghcr.io/mwasilew/docker-mkbootimage:master
+        image: artifacts.codelinaro.org/clo-420-qli-registry/kmake-image-ci:ver.1.0
         steps:
         - gunzip -c {{ ramdisk_name }} > initramfs-kerneltest-full-image-qcom-armv8a.cpio
         {% if firmware_name %}


### PR DESCRIPTION
Replace the external docker image references in fastboot.jinja2 and efi.jinja2 with Qualcomm registry image at
artifacts.codelinaro.org/clo-420-qli-registry/kmake-image-ci:ver.1.0.