### PR TITLE
metadata: Enable dtb for RB1 and Hamoa-IOT-EVK

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -21,6 +21,8 @@
         "dtbs/qcom/qcs615-ride.dtb": "",
         "dtbs/qcom/kaanapali-mtp.dtb": "",
         "dtbs/qcom/x1e80100-crd.dtb": "",
-        "dtbs/qcom/glymur-crd.dtb": ""
+        "dtbs/qcom/glymur-crd.dtb": "",
+        "dtbs/qcom/qrb2210-rb1.dtb": "",
+        "dtbs/qcom/hamoa-iot-evk.dtb": ""
     }
 }


### PR DESCRIPTION
Enable dtb for targets for tests enablement
in LAVA.
	- RB1
	- hamoa-iot-evk
