### PR TITLE
add: changes to run nightly with test binaries

### DIFF
--- a/templates/boot/flasher.jinja2
+++ b/templates/boot/flasher.jinja2
@@ -2,12 +2,20 @@
     images:
       image:
         url: '{{ node.artifacts.flash_image }}'
+      test:
+        headers:
+          Authorization: LAVA_BASIC_AUTH
+        url: 'https://storage-lava-hyd.qualcomm.com/Test_binaries.tar.gz'
     postprocess:
       docker:
         image: ghcr.io/mwasilew/docker-mkbootimage:master
         steps:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
+        - mkdir overlay_root
+        - tar -xzvf overlay.tar.gz -C overlay_root
+        - tar -xzvf Test_binaries.tar.gz -C overlay_root 
+        - tar -cvzf overlay.tar.gz -C overlay_root .
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
         - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=rootfs.img" >> $IMAGE_PATH/flash.settings

--- a/testList.json
+++ b/testList.json
@@ -1,6 +1,8 @@
 [
   {"type":"directory","name":".","contents":[
     {"type":"file","name":"qcom-next-ci-premerge.yaml"},
+    {"type":"file","name":"meta-qcom-nightly_config1.yaml"},
+    {"type":"file","name":"meta-qcom-nightly_config2.yaml"},
     {"type":"file","name":"meta-qcom_PreMerge.yaml"},
     {"type":"file","name":"fastrpc-premerge.yaml"},
     {"type":"file","name":"video_pre-merge.yaml"},


### PR DESCRIPTION
Add changes to run qcom-next nightly on config1/config2 with test binaries as overlay