### PR TITLE
metadata: Enable dtb for Targets

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -23,6 +23,8 @@
         "dtbs/qcom/x1e80100-crd.dtb": "",
         "dtbs/qcom/glymur-crd.dtb": "",
         "dtbs/qcom/qrb2210-rb1.dtb": "",
-        "dtbs/qcom/hamoa-iot-evk.dtb": ""
+        "dtbs/qcom/hamoa-iot-evk.dtb": "",
+        "dtbs/qcom/purwa-iot-evk.dtb": "",
+        "dtbs/qcom/shikra-iqs-evk.dtb": ""
     }
 }


### PR DESCRIPTION
Enable dtb for targets for tests enablement
in LAVA.
    - shikra-iqs-evk
    - purwa-iot-evk