### PR TITLE
flasher.jinja2 : Increase timeout for flash

### DIFF
--- a/templates/boot/flasher.jinja2
+++ b/templates/boot/flasher.jinja2
@@ -23,7 +23,7 @@
         - echo "PORT=0" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-     minutes: 30
+     minutes: 40
     to: downloads
 {% set flash_image_url = node.artifacts.flash_image %}
 {% set flash_image_path = flash_image_url.split('?')[0] %}
@@ -37,7 +37,7 @@
       overlay:
         url: downloads://overlay.tar.gz
     timeout:
-       minutes: 10
+       minutes: 20
     to: flasher
 - boot:
     auto_login:


### PR DESCRIPTION
Increase timeout for flash as in case of proprietary builds, the size of rootsfs image is around 1.8GB which is taking time to flash and flasher job gets timeout.